### PR TITLE
AdagioBidAdapter: change outstream renderer

### DIFF
--- a/test/spec/modules/adagioBidAdapter_spec.js
+++ b/test/spec/modules/adagioBidAdapter_spec.js
@@ -9,7 +9,7 @@ import {
   spec,
   ENDPOINT,
   VERSION,
-  RENDERER_URL,
+  BB_RENDERER_URL,
   GlobalExchange
 } from '../../../modules/adagioBidAdapter.js';
 import { loadExternalScript } from '../../../src/adloader.js';
@@ -76,6 +76,7 @@ describe('Adagio bid adapter', () => {
   let adagioMock;
   let utilsMock;
   let sandbox;
+  let fakeRenderer;
 
   const fixtures = {
     getElementById(width, height, x, y) {
@@ -1000,42 +1001,70 @@ describe('Adagio bid adapter', () => {
         context: 'outstream',
         playerSize: [[300, 250]],
         mimes: ['video/mp4'],
-        skip: true
+        skip: 1,
+        skipafter: 3
       };
 
       const serverResponseWithOutstream = utils.deepClone(serverResponse);
       serverResponseWithOutstream.body.bids[0].vastXml = '<VAST version="4.0"><Ad></Ad></VAST>';
       serverResponseWithOutstream.body.bids[0].mediaType = 'video';
-      serverResponseWithOutstream.body.bids[0].outstream = {
-        bvwUrl: 'https://foo.baz',
-        impUrl: 'https://foo.bar'
-      };
 
-      it('should set a renderer in video outstream context', function() {
+      const defaultRendererUrl = BB_RENDERER_URL.replace('$RENDERER', 'renderer');
+
+      it('should set related properties for video outstream context', function() {
         const bidResponse = spec.interpretResponse(serverResponseWithOutstream, bidRequestWithOutstream)[0];
-        expect(bidResponse).to.have.any.keys('outstream', 'renderer', 'mediaType');
+        expect(bidResponse).to.have.any.keys('renderer', 'mediaType');
         expect(bidResponse.renderer).to.be.a('object');
-        expect(bidResponse.renderer.url).to.equal(RENDERER_URL);
-        expect(bidResponse.renderer.config.bvwUrl).to.be.ok;
-        expect(bidResponse.renderer.config.impUrl).to.be.ok;
+        expect(bidResponse.renderer.url).to.equal(defaultRendererUrl);
         expect(bidResponse.renderer.loaded).to.not.be.ok;
         expect(bidResponse.width).to.equal(300);
         expect(bidResponse.height).to.equal(250);
         expect(bidResponse.vastUrl).to.match(/^data:text\/xml;/)
       });
 
-      it('should execute Adagio outstreamPlayer if defined', function() {
-        window.ADAGIO.outstreamPlayer = sinon.stub();
+      it('should execute Blue Billywig VAST Renderer bootstrap if defined', function() {
+        window.bluebillywig = {
+          renderers: [{ bootstrap: sinon.stub(), _id: 'adagio-renderer' }]
+        };
+
         const bidResponse = spec.interpretResponse(serverResponseWithOutstream, bidRequestWithOutstream)[0];
         executeRenderer(bidResponse.renderer, bidResponse)
-        sinon.assert.calledOnce(window.ADAGIO.outstreamPlayer);
-        delete window.ADAGIO.outstreamPlayer;
+        sinon.assert.calledOnce(window.bluebillywig.renderers[0].bootstrap);
+
+        delete window.bluebillywig;
       });
 
-      it('should logError if Adagio outstreamPlayer is not defined', function() {
+      it('Should logError if response does not have a vastXml or vastUrl', function() {
+        utilsMock.expects('logError').withExactArgs('Adagio: no vastXml or vastUrl on bid').once();
+
+        const localServerResponseWithOutstream = utils.deepClone(serverResponse);
+        localServerResponseWithOutstream.body.bids[0].mediaType = 'video';
+
+        const bidResponse = spec.interpretResponse(localServerResponseWithOutstream, bidRequestWithOutstream)[0];
+        executeRenderer(bidResponse.renderer, bidResponse)
+
+        utilsMock.verify();
+      })
+
+      it('should logError if Blue Billywig API is not defined', function() {
+        utilsMock.expects('logError').withExactArgs('Adagio: no BlueBillywig renderers found!').once();
+
         const bidResponse = spec.interpretResponse(serverResponseWithOutstream, bidRequestWithOutstream)[0];
         executeRenderer(bidResponse.renderer, bidResponse)
-        utilsMock.expects('logError').withExactArgs('Adagio: Adagio outstream player is not defined').once();
+
+        utilsMock.verify();
+      });
+
+      it('should logError if correct renderer is not defined', function() {
+        window.bluebillywig = { renderers: [ { _id: 'adagio-another_renderer' } ] };
+
+        utilsMock.expects('logError').withExactArgs('Adagio: couldn\'t find a renderer with ID adagio-renderer').once();
+
+        const bidResponse = spec.interpretResponse(serverResponseWithOutstream, bidRequestWithOutstream)[0];
+        executeRenderer(bidResponse.renderer, bidResponse)
+
+        delete window.bluebillywig;
+        utilsMock.verify();
       });
     });
 


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
