### PR TITLE
Adagio: adapt video outstream implementation details

### DIFF
--- a/modules/adagioBidAdapter.js
+++ b/modules/adagioBidAdapter.js
@@ -54,8 +54,9 @@ const ADAGIO_PUBKEY = 'AL16XT44Sfp+8SHVF1UdC7hydPSMVLMhsYknKDdwqq+0ToDSJrP0+Qh0k
 const ADAGIO_PUBKEY_E = 65537;
 const CURRENCY = 'USD';
 
-// This provide a whitelist and a basic validation of OpenRTB 2.6 options used by the Adagio SSP.
-// https://iabtechlab.com/wp-content/uploads/2022/04/OpenRTB-2-6_FINAL.pdf
+// This provide a whitelist and a basic validation of OpenRTB 2.5 options used by the Adagio SSP.
+// Accept all options but 'protocol', 'companionad', 'companiontype', 'ext'
+// https://www.iab.com/wp-content/uploads/2016/03/OpenRTB-API-Specification-Version-2-5-FINAL.pdf
 export const ORTB_VIDEO_PARAMS = {
   'mimes': (value) => Array.isArray(value) && value.length > 0 && value.every(v => typeof v === 'string'),
   'minduration': (value) => isInteger(value),

--- a/modules/adagioBidAdapter.md
+++ b/modules/adagioBidAdapter.md
@@ -107,10 +107,11 @@ var adUnits = [
           cpm: 3.00 // default to 1.00
         },
         video: {
-          api: [2, 7], // Required - Your video player must at least support the value 2 and/or 7.
+          api: [2], // Required - Your video player must at least support the value 2
           playbackMethod: [6], // Highly recommended
           skip: 0
-          // OpenRTB video options defined here override ones defined in mediaTypes.
+          // OpenRTB 2.5 video options defined here override ones defined in mediaTypes.
+          // Not supported: 'protocol', 'companionad', 'companiontype', 'ext'
         },
         native: {
           // Optional OpenRTB Native 1.2 request object. Only `context`, `plcmttype` fields are supported.
@@ -193,6 +194,8 @@ If the FPD value is an array, the 1st value of this array will be used.
           placement: 'in_article',
           adUnitElementId: 'article_outstream',
           video: {
+            api: [2],
+            playbackMethod: [6],
             skip: 0
           },
           debug: {


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
- [X] Other (No user-api changes only comments and documentation)

## Description of change
<!-- Describe the change proposed in this pull request -->
This pull request clarify the OpenRTB video params details accepted

* Adagio adapter is compatible with ORTB 2.5 only and not 2.6 as previously mentionned. 
* An example of video outstream bid has also been added


