### PR TITLE
Adagio Bid Adapter: support DSA digital service act

### DIFF
--- a/modules/adagioBidAdapter.js
+++ b/modules/adagioBidAdapter.js
@@ -990,6 +990,9 @@ export const spec = {
     const syncEnabled = deepAccess(config.getConfig('userSync'), 'syncEnabled')
     const usIfr = syncEnabled && userSync.canBidderRegisterSync('iframe', 'adagio')
 
+    // We don't validate the dsa object in adapter and let our server do it.
+    const dsa = deepAccess(bidderRequest, 'ortb2.regs.ext.dsa');
+
     const aucId = generateUUID()
 
     const adUnits = validBidRequests.map(rawBidRequest => {
@@ -1179,7 +1182,8 @@ export const spec = {
             coppa: coppa,
             ccpa: uspConsent,
             gpp: gppConsent.gpp,
-            gppSid: gppConsent.gppSid
+            gppSid: gppConsent.gppSid,
+            dsa: dsa // populated if exists
           },
           schain: schain,
           user: {
@@ -1216,6 +1220,7 @@ export const spec = {
             const bidReq = (find(bidRequest.data.adUnits, bid => bid.bidId === bidObj.requestId));
 
             if (bidReq) {
+              // bidObj.meta is the `bidResponse.meta` object according to https://docs.prebid.org/dev-docs/bidder-adaptor.html#interpreting-the-response
               bidObj.meta = deepAccess(bidObj, 'meta', {});
               bidObj.meta.mediaType = bidObj.mediaType;
               bidObj.meta.advertiserDomains = (Array.isArray(bidObj.aDomain) && bidObj.aDomain.length) ? bidObj.aDomain : [];

--- a/test/spec/modules/adagioBidAdapter_spec.js
+++ b/test/spec/modules/adagioBidAdapter_spec.js
@@ -975,6 +975,41 @@ describe('Adagio bid adapter', () => {
         expect(requests[0].data.adUnits[0].gpid).to.exist.and.equal(gpid);
       });
     });
+
+    describe('with DSA', function() {
+      it('should add DSA to the request', function() {
+        const dsaObject = {
+          dsarequired: 1,
+          pubrender: 1,
+          datatopub: 2,
+          transparency: [{
+            domain: 'domain.com',
+            dsaparams: [1, 2]
+          }]
+        }
+
+        const bid01 = new BidRequestBuilder().withParams().build();
+
+        const bidderRequest = new BidderRequestBuilder({
+          ortb2: {
+            regs: {
+              ext: {
+                dsa: dsaObject
+              }
+            }
+          }
+        }).build();
+        const requests = spec.buildRequests([bid01], bidderRequest);
+        expect(requests[0].data.regs.dsa).to.deep.equal(dsaObject);
+      });
+
+      it('should not add DSA to the request if not present', function() {
+        const bid01 = new BidRequestBuilder().withParams().build();
+        const bidderRequest = new BidderRequestBuilder().build();
+        const requests = spec.buildRequests([bid01], bidderRequest);
+        expect(requests[0].data.regs.dsa).to.be.undefined;
+      });
+    })
   });
 
   describe('interpretResponse()', function() {
@@ -1129,7 +1164,7 @@ describe('Adagio bid adapter', () => {
       utilsMock.verify();
     });
 
-    describe('Response with video outstream', () => {
+    describe('Response with video outstream', function() {
       const bidRequestWithOutstream = utils.deepClone(bidRequest);
       bidRequestWithOutstream.data.adUnits[0].mediaTypes.video = {
         context: 'outstream',
@@ -1202,7 +1237,7 @@ describe('Adagio bid adapter', () => {
       });
     });
 
-    describe('Response with native add', () => {
+    describe('Response with native add', function() {
       const serverResponseWithNative = utils.deepClone(serverResponse)
       serverResponseWithNative.body.bids[0].mediaType = 'native';
       serverResponseWithNative.body.bids[0].admNative = {
@@ -1379,6 +1414,24 @@ describe('Adagio bid adapter', () => {
         expect(r[0].native.javascriptTrackers).to.equal(expected);
       });
     });
+
+    describe('Response with DSA', function() {
+      const dsaResponseObj = {
+        'behalf': 'Advertiser',
+        'paid': 'Advertiser',
+        'transparency': {
+          'domain': 'dsp1domain.com',
+          'params': [1, 2]
+        },
+        'adrender': 1
+      };
+
+      const serverResponseWithDsa = utils.deepClone(serverResponse);
+      serverResponseWithDsa.body.bids[0].meta.dsa = dsaResponseObj;
+
+      const bidResponse = spec.interpretResponse(serverResponseWithDsa, bidRequest)[0];
+      expect(bidResponse.meta.dsa).to.to.deep.equals(dsaResponseObj);
+    })
   });
 
   describe('getUserSyncs()', function() {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change

Add support for DSA.

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
