### PR TITLE
Adagio Analytics: add bidder cpm to auction end event

### DIFF
--- a/modules/adagioAnalyticsAdapter.js
+++ b/modules/adagioAnalyticsAdapter.js
@@ -17,6 +17,8 @@ const ADAGIO_GVLID = 617;
 const VERSION = '3.0.0';
 const PREBID_VERSION = '$prebid.version$';
 const ENDPOINT = 'https://c.4dex.io/pba.gif';
+const CURRENCY_USD = 'USD';
+const ADAGIO_CODE = 'adagio';
 const cache = {
   auctions: {},
   getAuction: function(auctionId, adUnitCode) {
@@ -92,17 +94,11 @@ function removeDuplicates(arr, getKey) {
   });
 };
 
-function getAdapterNameForAlias(aliasName) {
-  return adapterManager.aliasRegistry[aliasName] || aliasName;
-};
-
-function isAdagio(value) {
-  if (!value) {
+function isAdagio(alias) {
+  if (!alias) {
     return false
   }
-
-  return value.toLowerCase().includes('adagio') ||
-    getAdapterNameForAlias(value).toLowerCase().includes('adagio');
+  return (alias + adapterManager.aliasRegistry[alias]).toLowerCase().includes(ADAGIO_CODE);
 };
 
 function getMediaTypeAlias(mediaType) {
@@ -127,6 +123,26 @@ function addKeyPrefix(obj, prefix) {
     acc[`${prefix}${key}`] = obj[key];
     return acc;
   }, {});
+}
+
+function getUsdCpm(cpm, currency) {
+  let netCpm = cpm
+
+  if (typeof currency === 'string' && currency.toUpperCase() !== CURRENCY_USD) {
+    if (typeof getGlobal().convertCurrency === 'function') {
+      netCpm = parseFloat(Number(getGlobal().convertCurrency(cpm, currency, CURRENCY_USD))).toFixed(3);
+    } else {
+      netCpm = null
+    }
+  }
+  return netCpm
+}
+
+function getCurrencyData(bid) {
+  return {
+    netCpm: getUsdCpm(bid.cpm, bid.currency),
+    orginalCpm: getUsdCpm(bid.originalCpm, bid.originalCurrency)
+  }
 }
 
 /**
@@ -258,7 +274,7 @@ function handlerAuctionInit(event) {
       t_v: params.testVersion || null,
       mts: mediaTypesKeys.join(','),
       ban_szs: bannerSizes.join(','),
-      bdrs: bidders.map(bidder => getAdapterNameForAlias(bidder.bidder)).sort().join(','),
+      bdrs: bidders.map(bidder => bidder.bidder).sort().join(','),
       adg_mts: adagioMediaTypes.join(',')
     };
 
@@ -299,15 +315,22 @@ function handlerAuctionEnd(event) {
 
   const adUnitCodes = cache.getAllAdUnitCodes(auctionId);
   adUnitCodes.forEach(adUnitCode => {
-    const mapper = (bidder) => event.bidsReceived.find(bid => bid.adUnitCode === adUnitCode && bid.bidder === bidder) ? '1' : '0';
+    const bidResponseMapper = (bidder) => {
+      const bid = event.bidsReceived.find(bid => bid.adUnitCode === adUnitCode && bid.bidder === bidder)
+      return bid ? '1' : '0'
+    }
+    const bidCpmMapper = (bidder) => {
+      const bid = event.bidsReceived.find(bid => bid.adUnitCode === adUnitCode && bid.bidder === bidder)
+      return bid ? getCurrencyData(bid).netCpm : null
+    }
 
     cache.updateAuction(auctionId, adUnitCode, {
-      bdrs_bid: cache.getBiddersFromAuction(auctionId, adUnitCode).map(mapper).join(',')
+      bdrs_bid: cache.getBiddersFromAuction(auctionId, adUnitCode).map(bidResponseMapper).join(','),
+      bdrs_cpm: cache.getBiddersFromAuction(auctionId, adUnitCode).map(bidCpmMapper).join(',')
     });
     sendNewBeacon(auctionId, adUnitCode);
   });
 }
-
 function handlerBidWon(event) {
   let auctionId = getTargetedAuctionId(event);
 
@@ -315,20 +338,7 @@ function handlerBidWon(event) {
     return;
   }
 
-  let adsCurRateToUSD = (event.currency === 'USD') ? 1 : null;
-  let ogCurRateToUSD = (event.originalCurrency === 'USD') ? 1 : null;
-  try {
-    if (typeof getGlobal().convertCurrency === 'function') {
-      // Currency module is loaded, we can calculate the conversion rate.
-
-      // Get the conversion rate from the original currency to USD.
-      ogCurRateToUSD = getGlobal().convertCurrency(1, event.originalCurrency, 'USD');
-      // Get the conversion rate from the ad server currency to USD.
-      adsCurRateToUSD = getGlobal().convertCurrency(1, event.currency, 'USD');
-    }
-  } catch (error) {
-    logError('Error on Adagio Analytics Adapter - handlerBidWon', error);
-  }
+  const currencyData = getCurrencyData(event)
 
   const adagioAuctionCacheId = (
     (event.latestTargetedAuctionId && event.latestTargetedAuctionId !== event.auctionId)
@@ -336,19 +346,12 @@ function handlerBidWon(event) {
       : null);
 
   cache.updateAuction(auctionId, event.adUnitCode, {
-    win_bdr: getAdapterNameForAlias(event.bidder),
+    win_bdr: event.bidder,
     win_mt: getMediaTypeAlias(event.mediaType),
     win_ban_sz: event.mediaType === BANNER ? `${event.width}x${event.height}` : null,
 
-    // ad server currency
-    win_cpm: event.cpm,
-    cur: event.currency,
-    cur_rate: adsCurRateToUSD,
-
-    // original currency from bidder
-    og_cpm: event.originalCpm,
-    og_cur: event.originalCurrency,
-    og_cur_rate: ogCurRateToUSD,
+    win_net_cpm: currencyData.netCpm,
+    win_og_cpm: currencyData.orginalCpm,
 
     // cache bid id
     auct_id_c: adagioAuctionCacheId,
@@ -428,7 +431,7 @@ adagioAdapter.enableAnalytics = config => {
 
 adapterManager.registerAnalyticsAdapter({
   adapter: adagioAdapter,
-  code: 'adagio',
+  code: ADAGIO_CODE,
   gvlid: ADAGIO_GVLID,
 });
 


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change
<!-- Describe the change proposed in this pull request -->
Track bids cpm in analytics module

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
