### PR TITLE
AdagioBidAdapter: remove auctionId override

### DIFF
--- a/modules/adagioBidAdapter.js
+++ b/modules/adagioBidAdapter.js
@@ -592,13 +592,8 @@ export const spec = {
       sessionData.rnd = Math.random()
     }
 
-    const aucId = deepAccess('bidderRequest', 'ortb2.site.ext.data.adg_rtd.uid') || generateUUID()
-
     const adUnits = validBidRequests.map(rawBidRequest => {
       const bidRequest = deepClone(rawBidRequest);
-
-      // Fix https://github.com/prebid/Prebid.js/issues/9781
-      bidRequest.auctionId = aucId
 
       // Force the Split Keyword to be a String
       if (bidRequest.params.splitKeyword) {
@@ -740,7 +735,6 @@ export const spec = {
     // Those params are not sent to the server.
     // They are used for further operations on analytics adapter.
     validBidRequests.forEach(rawBidRequest => {
-      rawBidRequest.params.adagioAuctionId = aucId
       rawBidRequest.params.pageviewId = pageviewId
     });
 

--- a/test/spec/modules/adagioBidAdapter_spec.js
+++ b/test/spec/modules/adagioBidAdapter_spec.js
@@ -277,8 +277,6 @@ describe('Adagio bid adapter', () => {
     it('should send bid request to ENDPOINT_PB via POST', function() {
       sandbox.stub(_internal, 'getDevice').returns({ a: 'a' });
       sandbox.stub(_internal, 'getSite').returns({ domain: 'adagio.io', 'page': 'https://adagio.io/hb' });
-      // sandbox.stub(_internal, 'getPageviewId').returns('1234-567');
-      // sandbox.stub(utils, 'generateUUID').returns('blabla');
 
       const bid01 = new BidRequestBuilder().withParams().build();
       const bidderRequest = new BidderRequestBuilder().build();
@@ -293,8 +291,7 @@ describe('Adagio bid adapter', () => {
     });
 
     it('should use a custom generated auctionId and remove transactionId', function() {
-      const expectedAuctionId = '373bcda7-9794-4f1c-be2c-0d223d11d579'
-      sandbox.stub(utils, 'generateUUID').returns(expectedAuctionId);
+      const expectedAuctionId = '4fd1ca2d-846c-4211-b9e5-321dfe1709c9'
 
       const bid01 = new BidRequestBuilder().withParams().build();
       const bidderRequest = new BidderRequestBuilder().build();
@@ -305,9 +302,7 @@ describe('Adagio bid adapter', () => {
     });
 
     it('should enrich prebid bid requests params', function() {
-      const expectedAuctionId = '373bcda7-9794-4f1c-be2c-0d223d11d579'
       const expectedPageviewId = '56befc26-8cf0-472d-b105-73896df8eb89';
-      sandbox.stub(utils, 'generateUUID').returns(expectedAuctionId);
       sandbox.stub(_internal, 'getAdagioNs').returns({ pageviewId: expectedPageviewId });
 
       const bid01 = new BidRequestBuilder().withParams().build();
@@ -315,7 +310,6 @@ describe('Adagio bid adapter', () => {
 
       spec.buildRequests([bid01], bidderRequest);
 
-      expect(bid01.params.adagioAuctionId).eq(expectedAuctionId);
       expect(bid01.params.pageviewId).eq(expectedPageviewId);
     });
 


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [x] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

To ensure compatibility with our backend while staying compliant with the behavior introduced in https://github.com/prebid/Prebid.js/issues/9781 we for some time generated our own specific auction id.

We will now rely on `source.tid`.

@osazos shall I add a similar error log in bid adapter when `enableTIDs` is not true ?

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
