### PR TITLE
 AdagioAnalyticsAdapter: remove auctionId override

### DIFF
--- a/modules/adagioAnalyticsAdapter.js
+++ b/modules/adagioAnalyticsAdapter.js
@@ -36,15 +36,6 @@ const cache = {
       ...values
     };
   },
-
-  // Map prebid auction id to adagio auction id
-  auctionIdReferences: {},
-  addPrebidAuctionIdRef(auctionId, adagioAuctionId) {
-    this.auctionIdReferences[auctionId] = adagioAuctionId;
-  },
-  getAdagioAuctionId(auctionId) {
-    return this.auctionIdReferences[auctionId];
-  }
 };
 const enc = window.encodeURIComponent;
 
@@ -250,9 +241,6 @@ function handlerAuctionInit(event) {
     // We assume that all Adagio bids for a same adunit have the same params.
     const params = adagioAdUnitBids[0].params;
 
-    const adagioAuctionId = params.adagioAuctionId;
-    cache.addPrebidAuctionIdRef(prebidAuctionId, adagioAuctionId);
-
     // Get all media types requested for Adagio.
     const adagioMediaTypes = removeDuplicates(
       adagioAdUnitBids.map(bid => Object.keys(bid.mediaTypes)).flat(),
@@ -265,7 +253,7 @@ function handlerAuctionInit(event) {
       org_id: params.organizationId,
       site: params.site,
       pv_id: params.pageviewId,
-      auct_id: adagioAuctionId,
+      auct_id: prebidAuctionId,
       adu_code: adUnitCode,
       url_dmn: w.location.hostname,
       pgtyp: params.pagetype,
@@ -342,9 +330,8 @@ function handlerBidWon(event) {
 
   const adagioAuctionCacheId = (
     (event.latestTargetedAuctionId && event.latestTargetedAuctionId !== event.auctionId)
-      ? cache.getAdagioAuctionId(event.auctionId)
+      ? event.auctionId
       : null);
-
   cache.updateAuction(auctionId, event.adUnitCode, {
     win_bdr: event.bidder,
     win_mt: getMediaTypeAlias(event.mediaType),

--- a/modules/adagioAnalyticsAdapter.js
+++ b/modules/adagioAnalyticsAdapter.js
@@ -9,6 +9,7 @@ import { ajax } from '../src/ajax.js';
 import { BANNER } from '../src/mediaTypes.js';
 import { getWindowTop, getWindowSelf, deepAccess, logInfo, logError } from '../src/utils.js';
 import { getGlobal } from '../src/prebidGlobal.js';
+import { config } from '../src/config.js';
 
 const emptyUrl = '';
 const analyticsType = 'endpoint';
@@ -404,7 +405,12 @@ let adagioAdapter = Object.assign(adapter({ emptyUrl, analyticsType }), {
 
 adagioAdapter.originEnableAnalytics = adagioAdapter.enableAnalytics;
 
-adagioAdapter.enableAnalytics = config => {
+adagioAdapter.enableAnalytics = adapterConfig => {
+  if (config.getConfig('enableTIDs') !== true) {
+    logError('Adagio Analytics Adapter requires prebid settings enableTIDs to be true. No beacon will be sent');
+    return;
+  }
+
   const w = (canAccessTopWindow()) ? getWindowTop() : getWindowSelf();
   currentWindow = w;
 
@@ -413,7 +419,7 @@ adagioAdapter.enableAnalytics = config => {
   w.ADAGIO.versions = w.ADAGIO.versions || {};
   w.ADAGIO.versions.adagioAnalyticsAdapter = VERSION;
 
-  adagioAdapter.originEnableAnalytics(config);
+  adagioAdapter.originEnableAnalytics(adapterConfig);
 }
 
 adapterManager.registerAnalyticsAdapter({

--- a/test/spec/modules/adagioAnalyticsAdapter_spec.js
+++ b/test/spec/modules/adagioAnalyticsAdapter_spec.js
@@ -178,9 +178,7 @@ describe('adagio analytics adapter - adagio.js', () => {
 });
 
 const AUCTION_ID = '25c6d7f5-699a-4bfc-87c9-996f915341fa';
-const AUCTION_ID_ADAGIO = '6fc53663-bde5-427b-ab63-baa9ed296f47'
 const AUCTION_ID_CACHE = 'b43d24a0-13d4-406d-8176-3181402bafc4';
-const AUCTION_ID_CACHE_ADAGIO = 'a9cae98f-efb5-477e-9259-27350044f8db';
 
 const BID_ADAGIO = {
   bidder: 'adagio',
@@ -395,8 +393,7 @@ const AUCTION_INIT_ANOTHER = {
     'bids': [ {
       'bidder': 'adagio',
       'params': {
-        ...PARAMS_ADG,
-        adagioAuctionId: AUCTION_ID_ADAGIO
+        ...PARAMS_ADG
       },
       'mediaTypes': {
         'banner': {
@@ -532,8 +529,7 @@ const AUCTION_INIT_CACHE = {
     'bids': [ {
       'bidder': 'adagio',
       'params': {
-        ...PARAMS_ADG,
-        adagioAuctionId: AUCTION_ID_CACHE_ADAGIO
+        ...PARAMS_ADG
       },
       'mediaTypes': {
         'banner': {
@@ -676,7 +672,7 @@ describe('adagio analytics adapter', () => {
         expect(pathname).to.equal('/pba.gif');
         expect(search.v).to.equal('1');
         expect(search.pbjsv).to.equal('$prebid.version$');
-        expect(search.auct_id).to.equal(AUCTION_ID_ADAGIO);
+        expect(search.auct_id).to.equal(AUCTION_ID);
         expect(search.adu_code).to.equal('/19968336/header-bid-tag-1');
         expect(search.org_id).to.equal('1001');
         expect(search.site).to.equal('test-com');
@@ -708,7 +704,7 @@ describe('adagio analytics adapter', () => {
         expect(hostname).to.equal('c.4dex.io');
         expect(pathname).to.equal('/pba.gif');
         expect(search.v).to.equal('3');
-        expect(search.auct_id).to.equal(AUCTION_ID_ADAGIO);
+        expect(search.auct_id).to.equal(AUCTION_ID);
         expect(search.adu_code).to.equal('/19968336/header-bid-tag-1');
         expect(search.win_bdr).to.equal('another');
         expect(search.win_mt).to.equal('ban');
@@ -749,7 +745,7 @@ describe('adagio analytics adapter', () => {
         expect(pathname).to.equal('/pba.gif');
         expect(search.v).to.equal('1');
         expect(search.pbjsv).to.equal('$prebid.version$');
-        expect(search.auct_id).to.equal(AUCTION_ID_CACHE_ADAGIO);
+        expect(search.auct_id).to.equal(AUCTION_ID_CACHE);
         expect(search.adu_code).to.equal('/19968336/header-bid-tag-1');
         expect(search.org_id).to.equal('1001');
         expect(search.site).to.equal('test-com');
@@ -772,7 +768,7 @@ describe('adagio analytics adapter', () => {
         expect(pathname).to.equal('/pba.gif');
         expect(search.v).to.equal('1');
         expect(search.pbjsv).to.equal('$prebid.version$');
-        expect(search.auct_id).to.equal(AUCTION_ID_ADAGIO);
+        expect(search.auct_id).to.equal(AUCTION_ID);
         expect(search.adu_code).to.equal('/19968336/header-bid-tag-1');
         expect(search.org_id).to.equal('1001');
         expect(search.site).to.equal('test-com');
@@ -804,8 +800,8 @@ describe('adagio analytics adapter', () => {
         expect(hostname).to.equal('c.4dex.io');
         expect(pathname).to.equal('/pba.gif');
         expect(search.v).to.equal('3');
-        expect(search.auct_id).to.equal(AUCTION_ID_ADAGIO);
-        expect(search.auct_id_c).to.equal(AUCTION_ID_CACHE_ADAGIO);
+        expect(search.auct_id).to.equal(AUCTION_ID);
+        expect(search.auct_id_c).to.equal(AUCTION_ID_CACHE);
         expect(search.adu_code).to.equal('/19968336/header-bid-tag-1');
         expect(search.win_bdr).to.equal('adagio');
         expect(search.win_mt).to.equal('ban');
@@ -821,8 +817,8 @@ describe('adagio analytics adapter', () => {
         expect(hostname).to.equal('c.4dex.io');
         expect(pathname).to.equal('/pba.gif');
         expect(search.v).to.equal('4');
-        expect(search.auct_id).to.equal(AUCTION_ID_ADAGIO);
-        expect(search.auct_id_c).to.equal(AUCTION_ID_CACHE_ADAGIO);
+        expect(search.auct_id).to.equal(AUCTION_ID);
+        expect(search.auct_id_c).to.equal(AUCTION_ID_CACHE);
         expect(search.adu_code).to.equal('/19968336/header-bid-tag-1');
         expect(search.rndr).to.equal('0');
       }


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [x] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

To ensure compatibility with our backend while staying compliant with the behavior introduced in https://github.com/prebid/Prebid.js/issues/9781 we for some time generated our own specific auction id.

We will now rely on source.tid, thus requiring publishers to set `enableTIDs` to `true`.
The analyticsAdapter won't start if this option is not set to `true`

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
Related to https://github.com/onfocusio/Prebid.js/pull/44