### PR TITLE
AdagioAnalyticsAdapter: add "bdrs_code" to beacon

### DIFF
--- a/modules/adagioAnalyticsAdapter.js
+++ b/modules/adagioAnalyticsAdapter.js
@@ -214,14 +214,16 @@ function handlerAuctionInit(event) {
       bannerSize => bannerSize
     ).sort();
 
-    const sortedBidderCodes = bidders.sort()
+    const sortedBidderNames = bidders.sort();
 
     const bidSrcMapper = (bidder) => {
+      // bidderCode in the context of the bidderRequest is the name given to the bidder in the adunit.
+      // It is not always the "true" bidder code, it can also be its alias
       const request = event.bidderRequests.find(br => br.bidderCode === bidder)
       return request ? request.bids[0].src : null
     }
-    const biddersSrc = sortedBidderCodes.map(bidSrcMapper).join(',');
-    const biddersCode = sortedBidderCodes.map(bidder => adapterManager.resolveAlias(bidder)).join(',');
+    const biddersSrc = sortedBidderNames.map(bidSrcMapper).join(',');
+    const biddersCode = sortedBidderNames.map(bidder => adapterManager.resolveAlias(bidder)).join(',');
 
     // if adagio was involved in the auction we identified it with rtdUid, if not use the prebid auctionId
     const auctionId = rtdUid || prebidAuctionId;
@@ -239,7 +241,7 @@ function handlerAuctionInit(event) {
       url_dmn: w.location.hostname,
       mts: mediaTypesKeys.join(','),
       ban_szs: bannerSizes.join(','),
-      bdrs: sortedBidderCodes.join(','),
+      bdrs: sortedBidderNames.join(','),
       pgtyp: deepAccess(event.bidderRequests[0], 'ortb2.site.ext.data.pagetype', null),
       plcmt: deepAccess(adUnits[0], 'ortb2Imp.ext.data.placement', null),
       t_n: adgRtdSession.testName || null,
@@ -247,7 +249,7 @@ function handlerAuctionInit(event) {
       s_id: adgRtdSession.id || null,
       s_new: adgRtdSession.new || null,
       bdrs_src: biddersSrc,
-      bdrs_code: biddersCodes,
+      bdrs_code: biddersCode,
     };
 
     if (adagioBidRequest && adagioBidRequest.bids) {

--- a/modules/adagioAnalyticsAdapter.js
+++ b/modules/adagioAnalyticsAdapter.js
@@ -221,6 +221,7 @@ function handlerAuctionInit(event) {
       return request ? request.bids[0].src : null
     }
     const biddersSrc = sortedBidderCodes.map(bidSrcMapper).join(',');
+    const biddersCode = sortedBidderCodes.map(bidder => adapterManager.resolveAlias(bidder)).join(',');
 
     // if adagio was involved in the auction we identified it with rtdUid, if not use the prebid auctionId
     const auctionId = rtdUid || prebidAuctionId;
@@ -246,6 +247,7 @@ function handlerAuctionInit(event) {
       s_id: adgRtdSession.id || null,
       s_new: adgRtdSession.new || null,
       bdrs_src: biddersSrc,
+      bdrs_code: biddersCodes,
     };
 
     if (adagioBidRequest && adagioBidRequest.bids) {

--- a/test/spec/modules/adagioAnalyticsAdapter_spec.js
+++ b/test/spec/modules/adagioAnalyticsAdapter_spec.js
@@ -244,6 +244,11 @@ const AUCTION_INIT_ANOTHER = {
       'params': {
         ...PARAMS_ADG
       },
+    }, {
+      'bidder': 'anotherWithAlias',
+      'params': {
+        'publisherId': '1001'
+      },
     }, ],
     'transactionId': 'ca4af27a-6d02-4f90-949d-d5541fa12014',
     'ortb2Imp': {
@@ -340,7 +345,25 @@ const AUCTION_INIT_ANOTHER = {
       'auctionId': AUCTION_ID,
       'src': 'client',
       'bidRequestsCount': 1
-    }
+    }, {
+      'bidder': 'anotherWithAlias',
+      'params': {
+        'publisherId': '1001',
+      },
+      'mediaTypes': {
+        'banner': {
+          'sizes': [[640, 480]]
+        }
+      },
+      'adUnitCode': '/19968336/header-bid-tag-1',
+      'transactionId': 'ca4af27a-6d02-4f90-949d-d5541fa12014',
+      'sizes': [[640, 480]],
+      'bidId': '2ecff0db240757',
+      'bidderRequestId': '1be65d7958826a',
+      'auctionId': AUCTION_ID,
+      'src': 'client',
+      'bidRequestsCount': 1
+    },
     ],
     'timeout': 3000,
     'refererInfo': {
@@ -682,10 +705,12 @@ describe('adagio analytics adapter', () => {
           site: 'test-com',
         }
       });
+      adapterManager.aliasRegistry['anotherWithAlias'] = 'another';
     });
 
     afterEach(() => {
       adagioAnalyticsAdapter.disableAnalytics();
+      delete adapterManager.aliasRegistry['anotherWithAlias'];
     });
 
     it('builds and sends auction data', () => {
@@ -715,7 +740,8 @@ describe('adagio analytics adapter', () => {
         expect(search.plcmt).to.equal('pave_top');
         expect(search.mts).to.equal('ban');
         expect(search.ban_szs).to.equal('640x100,640x480');
-        expect(search.bdrs).to.equal('adagio,another,nobid');
+        expect(search.bdrs).to.equal('adagio,another,anotherWithAlias,nobid');
+        expect(search.bdrs_code).to.equal('adagio,another,another,nobid');
         expect(search.adg_mts).to.equal('ban');
       }
 
@@ -736,8 +762,8 @@ describe('adagio analytics adapter', () => {
         expect(search.adu_code).to.equal('/19968336/header-bid-tag-1');
         expect(search.e_sid).to.equal('42');
         expect(search.e_pba_test).to.equal('true');
-        expect(search.bdrs_bid).to.equal('1,1,0');
-        expect(search.bdrs_cpm).to.equal('1.42,2.052,');
+        expect(search.bdrs_bid).to.equal('1,1,0,0');
+        expect(search.bdrs_cpm).to.equal('1.42,2.052,,');
       }
 
       {
@@ -796,6 +822,7 @@ describe('adagio analytics adapter', () => {
         expect(search.mts).to.equal('ban');
         expect(search.ban_szs).to.equal('640x100,640x480');
         expect(search.bdrs).to.equal('adagio,another');
+        expect(search.bdrs_code).to.equal('adagio,another');
         expect(search.adg_mts).to.equal('ban');
         expect(search.t_n).to.equal('test');
         expect(search.t_v).to.equal('version');
@@ -819,6 +846,7 @@ describe('adagio analytics adapter', () => {
         expect(search.mts).to.equal('ban');
         expect(search.ban_szs).to.equal('640x480');
         expect(search.bdrs).to.equal('another');
+        expect(search.bdrs_code).to.equal('another');
         expect(search.adg_mts).to.not.exist;
       }
 
@@ -839,7 +867,8 @@ describe('adagio analytics adapter', () => {
         expect(search.plcmt).to.equal('pave_top');
         expect(search.mts).to.equal('ban');
         expect(search.ban_szs).to.equal('640x100,640x480');
-        expect(search.bdrs).to.equal('adagio,another,nobid');
+        expect(search.bdrs).to.equal('adagio,another,anotherWithAlias,nobid');
+        expect(search.bdrs_code).to.equal('adagio,another,another,nobid');
         expect(search.adg_mts).to.equal('ban');
       }
 
@@ -864,8 +893,8 @@ describe('adagio analytics adapter', () => {
         expect(search.adu_code).to.equal('/19968336/header-bid-tag-1');
         expect(search.e_sid).to.equal('42');
         expect(search.e_pba_test).to.equal('true');
-        expect(search.bdrs_bid).to.equal('0,0,0');
-        expect(search.bdrs_cpm).to.equal(',,');
+        expect(search.bdrs_bid).to.equal('0,0,0,0');
+        expect(search.bdrs_cpm).to.equal(',,,');
       }
 
       {
@@ -939,8 +968,8 @@ describe('adagio analytics adapter', () => {
         expect(search.v).to.equal('2');
         expect(search.e_sid).to.equal('42');
         expect(search.e_pba_test).to.equal('true');
-        expect(search.bdrs_bid).to.equal('1,1,0');
-        expect(search.bdrs_cpm).to.equal('1.42,,');
+        expect(search.bdrs_bid).to.equal('1,1,0,0');
+        expect(search.bdrs_cpm).to.equal('1.42,,,');
       }
     });
   });


### PR DESCRIPTION
# Add `bdrs_code` to beacon

## Type of change
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter 
- [x] Updated bidder adapter
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
We want to know which bidder is really called when the bidder name is an alias.

## Other information
