### PR TITLE
AdagioAnalyticsAdapter: track revelant ad-units only

### DIFF
--- a/modules/adagioAnalyticsAdapter.js
+++ b/modules/adagioAnalyticsAdapter.js
@@ -68,6 +68,7 @@ const cache = {
     return { auctionId: null, adUnitCode: null }
   }
 };
+
 const enc = window.encodeURIComponent;
 
 /**
@@ -195,7 +196,14 @@ function handlerAuctionInit(event) {
   const w = getBestWindowForAdagio();
 
   const prebidAuctionId = event.auctionId;
-  const adUnitCodes = removeDuplicates(event.adUnitCodes, adUnitCode => adUnitCode);
+
+  // adUnitCodes come from `event.bidderRequests` to be sure to keep the ad-units that are valid and will be effectively used during the auction.
+  // This array can be different than `event.adUnitCodes` because of the usage of conditionnal ad-units (see: https://docs.prebid.org/dev-docs/conditional-ad-units.html)
+  const adUnitCodes = new Set(
+    event.bidderRequests
+      .map(br => br.bids.map(bid => bid.adUnitCode))
+      .flat()
+  );
 
   // Check if Adagio is on the bid requests.
   const adagioBidRequest = event.bidderRequests.find(bidRequest => isAdagio(bidRequest.bidderCode));
@@ -207,6 +215,7 @@ function handlerAuctionInit(event) {
 
   adUnitCodes.forEach(adUnitCode => {
     // event.adUnits are splitted by mediatypes
+    // having twin ad-unit codes is ok: https://docs.prebid.org/dev-docs/adunit-reference.html#twin-adunit-codes
     const adUnits = event.adUnits.filter(adUnit => adUnit.code === adUnitCode);
 
     // Get all bidders configured for the ad unit.
@@ -236,6 +245,7 @@ function handlerAuctionInit(event) {
       const request = event.bidderRequests.find(br => br.bidderCode === bidder)
       return request ? request.bids[0].src : null
     }
+
     const biddersSrc = sortedBidderNames.map(bidSrcMapper).join(',');
     const biddersCode = sortedBidderNames.map(bidder => adapterManager.resolveAlias(bidder)).join(',');
 

--- a/test/spec/modules/adagioAnalyticsAdapter_spec.js
+++ b/test/spec/modules/adagioAnalyticsAdapter_spec.js
@@ -287,141 +287,192 @@ const AUCTION_INIT_ANOTHER = {
     },
   } ],
   'adUnitCodes': ['/19968336/header-bid-tag-1', '/19968336/footer-bid-tag-1'],
-  'bidderRequests': [ {
-    'bidderCode': 'another',
-    'auctionId': AUCTION_ID,
-    'bidderRequestId': '1be65d7958826a',
-    'bids': [ {
-      'bidder': 'another',
-      'params': {
-        'publisherId': '1001',
-      },
-      'mediaTypes': {
-        'banner': {
-          'sizes': [[640, 480]]
-        }
-      },
-      'adUnitCode': '/19968336/header-bid-tag-1',
-      'transactionId': 'ca4af27a-6d02-4f90-949d-d5541fa12014',
-      'sizes': [[640, 480]],
-      'bidId': '2ecff0db240757',
-      'bidderRequestId': '1be65d7958826a',
+  'bidderRequests': [
+    {
+      'bidderCode': 'another',
       'auctionId': AUCTION_ID,
-      'src': 'client',
-      'bidRequestsCount': 1
-    }, {
-      'bidder': 'another',
-      'params': {
-        'publisherId': '1001'
-      },
-      'mediaTypes': {
-        'banner': {
-          'sizes': [[640, 480]]
-        }
-      },
-      'adUnitCode': '/19968336/footer-bid-tag-1',
-      'transactionId': 'ca4af27a-6d02-4f90-949d-d5541fa12014',
-      'sizes': [[640, 480]],
-      'bidId': '2ecff0db240757',
       'bidderRequestId': '1be65d7958826a',
-      'auctionId': AUCTION_ID,
-      'src': 'client',
-      'bidRequestsCount': 1
-    }, {
-      'bidder': 'nobid',
-      'params': {
-        'publisherId': '1001'
+      'bids': [
+        {
+          'bidder': 'another',
+          'params': {
+            'publisherId': '1001',
+          },
+          'mediaTypes': {
+            'banner': {
+              'sizes': [[640, 480]]
+            }
+          },
+          'adUnitCode': '/19968336/header-bid-tag-1',
+          'transactionId': 'ca4af27a-6d02-4f90-949d-d5541fa12014',
+          'sizes': [[640, 480]],
+          'bidId': '2ecff0db240757',
+          'bidderRequestId': '1be65d7958826a',
+          'auctionId': AUCTION_ID,
+          'src': 'client',
+          'bidRequestsCount': 1
+        },
+        {
+          'bidder': 'another',
+          'params': {
+            'publisherId': '1001'
+          },
+          'mediaTypes': {
+            'banner': {
+              'sizes': [[640, 480]]
+            }
+          },
+          'adUnitCode': '/19968336/footer-bid-tag-1',
+          'transactionId': 'ca4af27a-6d02-4f90-949d-d5541fa12014',
+          'sizes': [[640, 480]],
+          'bidId': '2ecff0db240757',
+          'bidderRequestId': '1be65d7958826a',
+          'auctionId': AUCTION_ID,
+          'src': 'client',
+          'bidRequestsCount': 1
+        },
+      ],
+      'timeout': 3000,
+      'refererInfo': {
+        'topmostLocation': 'http://www.test.com/page.html', 'reachedTop': true, 'numIframes': 0, 'stack': ['http://www.test.com/page.html']
       },
-      'mediaTypes': {
-        'banner': {
-          'sizes': [[640, 480]]
+      'ortb2': {
+        'site': {
+          'ext': {
+            'data': {
+              'adg_rtd': {
+                ...ADG_RTD
+              },
+              ...ORTB_DATA
+            }
+          }
         }
-      },
-      'adUnitCode': '/19968336/footer-bid-tag-1',
-      'transactionId': 'ca4af27a-6d02-4f90-949d-d5541fa12014',
-      'sizes': [[640, 480]],
-      'bidId': '2ecff0db240757',
-      'bidderRequestId': '1be65d7958826a',
-      'auctionId': AUCTION_ID,
-      'src': 'client',
-      'bidRequestsCount': 1
-    }, {
-      'bidder': 'anotherWithAlias',
-      'params': {
-        'publisherId': '1001',
-      },
-      'mediaTypes': {
-        'banner': {
-          'sizes': [[640, 480]]
-        }
-      },
-      'adUnitCode': '/19968336/header-bid-tag-1',
-      'transactionId': 'ca4af27a-6d02-4f90-949d-d5541fa12014',
-      'sizes': [[640, 480]],
-      'bidId': '2ecff0db240757',
-      'bidderRequestId': '1be65d7958826a',
-      'auctionId': AUCTION_ID,
-      'src': 'client',
-      'bidRequestsCount': 1
+      }
     },
-    ],
-    'timeout': 3000,
-    'refererInfo': {
-      'topmostLocation': 'http://www.test.com/page.html', 'reachedTop': true, 'numIframes': 0, 'stack': ['http://www.test.com/page.html']
+    {
+      'bidderCode': 'nobid',
+      'auctionId': AUCTION_ID,
+      'bidderRequestId': '1be65d7958826a',
+      'bids': [{
+        'bidder': 'nobid',
+        'params': {
+          'publisherId': '1001'
+        },
+        'mediaTypes': {
+          'banner': {
+            'sizes': [[640, 480]]
+          }
+        },
+        'adUnitCode': '/19968336/header-bid-tag-1',
+        'transactionId': 'ca4af27a-6d02-4f90-949d-d5541fa12014',
+        'sizes': [[640, 480]],
+        'bidId': '2ecff0db240757',
+        'bidderRequestId': '1be65d7958826a',
+        'auctionId': AUCTION_ID,
+        'src': 'client',
+        'bidRequestsCount': 1
+      }
+      ],
+      'timeout': 3000,
+      'refererInfo': {
+        'topmostLocation': 'http://www.test.com/page.html', 'reachedTop': true, 'numIframes': 0, 'stack': ['http://www.test.com/page.html']
+      },
+      'ortb2': {
+        'site': {
+          'ext': {
+            'data': {
+              'adg_rtd': {
+                ...ADG_RTD
+              },
+              ...ORTB_DATA
+            }
+          }
+        }
+      }
     },
-    'ortb2': {
-      'site': {
-        'ext': {
-          'data': {
-            'adg_rtd': {
-              ...ADG_RTD
-            },
-            ...ORTB_DATA
+    {
+      bidderCode: 'anotherWithAlias',
+      'auctionId': AUCTION_ID,
+      'bidderRequestId': '1be65d7958826a',
+      'bids': [
+        {
+          'bidder': 'anotherWithAlias',
+          'params': {
+            'publisherId': '1001',
+          },
+          'mediaTypes': {
+            'banner': {
+              'sizes': [[640, 480]]
+            }
+          },
+          'adUnitCode': '/19968336/header-bid-tag-1',
+          'transactionId': 'ca4af27a-6d02-4f90-949d-d5541fa12014',
+          'sizes': [[640, 480]],
+          'bidId': '2ecff0db240757',
+          'bidderRequestId': '1be65d7958826a',
+          'auctionId': AUCTION_ID,
+          'src': 'client',
+          'bidRequestsCount': 1
+        },
+      ],
+      'timeout': 3000,
+      'refererInfo': {
+        'topmostLocation': 'http://www.test.com/page.html', 'reachedTop': true, 'numIframes': 0, 'stack': ['http://www.test.com/page.html']
+      },
+      'ortb2': {
+        'site': {
+          'ext': {
+            'data': {
+              'adg_rtd': {
+                ...ADG_RTD
+              },
+              ...ORTB_DATA
+            }
+          }
+        }
+      }
+    },
+    {
+      'bidderCode': 'adagio',
+      'auctionId': AUCTION_ID,
+      'bidderRequestId': '1be65d7958826a',
+      'bids': [ {
+        'bidder': 'adagio',
+        'params': {
+          ...PARAMS_ADG
+        },
+        'mediaTypes': {
+          'banner': {
+            'sizes': [[640, 480]]
+          }
+        },
+        'adUnitCode': '/19968336/header-bid-tag-1',
+        'transactionId': 'ca4af27a-6d02-4f90-949d-d5541fa12014',
+        'sizes': [[640, 480]],
+        'bidId': '2ecff0db240757',
+        'bidderRequestId': '1be65d7958826a',
+        'auctionId': AUCTION_ID,
+        'src': 'client',
+        'bidRequestsCount': 1
+      }
+      ],
+      'timeout': 3000,
+      'refererInfo': {
+        'topmostLocation': 'http://www.test.com/page.html', 'reachedTop': true, 'numIframes': 0, 'stack': ['http://www.test.com/page.html']
+      },
+      'ortb2': {
+        'site': {
+          'ext': {
+            'data': {
+              'adg_rtd': {
+                ...ADG_RTD
+              },
+              ...ORTB_DATA
+            }
           }
         }
       }
     }
-  }, {
-    'bidderCode': 'adagio',
-    'auctionId': AUCTION_ID,
-    'bidderRequestId': '1be65d7958826a',
-    'bids': [ {
-      'bidder': 'adagio',
-      'params': {
-        ...PARAMS_ADG
-      },
-      'mediaTypes': {
-        'banner': {
-          'sizes': [[640, 480]]
-        }
-      },
-      'adUnitCode': '/19968336/header-bid-tag-1',
-      'transactionId': 'ca4af27a-6d02-4f90-949d-d5541fa12014',
-      'sizes': [[640, 480]],
-      'bidId': '2ecff0db240757',
-      'bidderRequestId': '1be65d7958826a',
-      'auctionId': AUCTION_ID,
-      'src': 'client',
-      'bidRequestsCount': 1
-    }
-    ],
-    'timeout': 3000,
-    'refererInfo': {
-      'topmostLocation': 'http://www.test.com/page.html', 'reachedTop': true, 'numIframes': 0, 'stack': ['http://www.test.com/page.html']
-    },
-    'ortb2': {
-      'site': {
-        'ext': {
-          'data': {
-            'adg_rtd': {
-              ...ADG_RTD
-            },
-            ...ORTB_DATA
-          }
-        }
-      }
-    }
-  }
   ],
   'bidsReceived': [],
   'winningBids': [],


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

We had chosen to rely on the `event.adUnitCodes` array to define which adUnitCodes must be tracked, but it was wrong because this array doesn't store which adUnitCodes are effectively used during the auction. In some scenario, an adUnit can be ignored due to specific configuration (typically, conditional ad-units).
Now, we rely on what is present in the `event.bidderRequests` array.

Note: the fixture in the adagioAnalyticsAdapter_spec.js file has been fixed in order to fit the real expected object
