### PR TITLE
[sc-15609] RTD: hasRtd flag support for multiple concurrnet prebid.js…

### DIFF
--- a/libraries/adagioUtils/adagioUtils.js
+++ b/libraries/adagioUtils/adagioUtils.js
@@ -31,5 +31,10 @@ export const _ADAGIO = (function() {
   w.ADAGIO.windows = w.ADAGIO.windows || [];
   w.ADAGIO.isSafeFrameWindow = isSafeFrameWindow();
 
+  w.ADAGIO.hasRtd = w.ADAGIO.hasRtd || {};
+  if (w.ADAGIO.hasRtd['$prebid.version$'] === undefined) {
+    w.ADAGIO.hasRtd['$prebid.version$'] = false
+  }
+
   return w.ADAGIO;
 })();

--- a/modules/adagioRtdProvider.js
+++ b/modules/adagioRtdProvider.js
@@ -264,7 +264,7 @@ function init(config, _userConsent) {
     return false;
   }
 
-  _internal.getAdagioNs().hasRtd = true;
+  _internal.getAdagioNs().hasRtd['$prebid.version$'] = true;
 
   _internal.getSession().init();
 


### PR DESCRIPTION
This is a suggestion to fix the issue with the flag `ADAGIO.hasRtd` when multiple Prebid.js versions are active at the same time.

Previously, if one of the prebid versions didn't have the rtd provider enabled and the other had it, the flag `hasRtd` would be `true`, which would result in incorrect behavior [in adagio.js](https://github.com/onfocusio/adagio-js/blob/c7f08edc51734c29a8b3268cf86038fd75abd4a9/src/index.js#L1165).

TODO: update tests.