### PR TITLE
Adagio multi modules: rollback params.placement depreciation

### DIFF
--- a/modules/adagioAnalyticsAdapter.js
+++ b/modules/adagioAnalyticsAdapter.js
@@ -267,7 +267,7 @@ function handlerAuctionInit(event) {
       ban_szs: bannerSizes.join(','),
       bdrs: sortedBidderNames.join(','),
       pgtyp: deepAccess(event.bidderRequests[0], 'ortb2.site.ext.data.pagetype', null),
-      plcmt: deepAccess(adUnits[0], 'ortb2Imp.ext.data.placement', null),
+      plcmt: deepAccess(adUnits[0], 'ortb2Imp.ext.data.adg_rtd.placement', null), // adg_rtd.placement is set by AdagioRtdProvider.
       t_n: adgRtdSession.testName || null,
       t_v: adgRtdSession.testVersion || null,
       s_id: adgRtdSession.id || null,
@@ -289,6 +289,11 @@ function handlerAuctionInit(event) {
         // for backward compatibility: if we didn't find organizationId & site but we have a bid from adagio we might still find it in params
         qp.org_id = qp.org_id || adagioAdUnitBids[0].params.organizationId;
         qp.site = qp.site || adagioAdUnitBids[0].params.site;
+
+        // `qp.plcmt` uses the value set by the AdagioRtdProvider. If not present, we fallback on the value set at the adUnit.params level.
+        if (!qp.plcmt) {
+          qp.plcmt = deepAccess(adagioAdUnitBids[0], 'params.placement', null);
+        }
       }
     }
 

--- a/modules/adagioBidAdapter.js
+++ b/modules/adagioBidAdapter.js
@@ -399,11 +399,18 @@ function autoFillParams(bid) {
     bid.params.site = adgGlobalConf.siteId.split(':')[1];
   }
 
-  // `useAdUnitCodeAsPlacement` is an edge case. Useful when a Prebid Manager cannot handle properly params setting.
-  // In Prebid.js 9, `placement` should be defined in ortb2Imp and the `useAdUnitCodeAsPlacement` param should be removed
-  bid.params.placement = deepAccess(bid, 'ortb2Imp.ext.data.placement', bid.params.placement);
-  if (!bid.params.placement && (adgGlobalConf.useAdUnitCodeAsPlacement === true || bid.params.useAdUnitCodeAsPlacement === true)) {
-    bid.params.placement = bid.adUnitCode;
+  if (!bid.params.placement) {
+    let p = deepAccess(bid, 'ortb2Imp.ext.data.adg_rtd.placement', '');
+    if (!p) {
+      // Use ortb2Imp.ext.data.placement for backward compatibility.
+      p = deepAccess(bid, 'ortb2Imp.ext.data.placement', '');
+    }
+
+    // `useAdUnitCodeAsPlacement` is an edge case. Useful when a Prebid Manager cannot handle properly params setting.
+    if (!p && bid.params.useAdUnitCodeAsPlacement === true) {
+      p = bid.adUnitCode;
+    }
+    bid.params.placement = p;
   }
 
   bid.params.adUnitElementId = deepAccess(bid, 'ortb2Imp.ext.data.divId', bid.params.adUnitElementId);

--- a/modules/adagioRtdProvider.js
+++ b/modules/adagioRtdProvider.js
@@ -47,7 +47,7 @@ export const PLACEMENT_SOURCES = {
 };
 export const storage = getStorageManager({ moduleType: MODULE_TYPE_RTD, moduleName: SUBMODULE_NAME });
 
-const { logError, logWarn } = prefixLog('AdagioRtdProvider:');
+const { logError, logInfo, logWarn } = prefixLog('AdagioRtdProvider:');
 
 // Guard to avoid storing the same bid data several times.
 const guard = new Set();
@@ -238,6 +238,25 @@ export const _internal = {
         return value;
       }
     });
+  },
+
+  // Compute the placement from the legacy RTD config params or ortb2Imp.ext.data.placement key.
+  computePlacementFromLegacy: function(rtdConfig, adUnit) {
+    const placementSource = deepAccess(rtdConfig, 'params.placementSource', '');
+    let placementFromSource = '';
+
+    switch (placementSource.toLowerCase()) {
+      case PLACEMENT_SOURCES.ADUNITCODE:
+        placementFromSource = adUnit.code;
+        break;
+      case PLACEMENT_SOURCES.GPID:
+        placementFromSource = deepAccess(adUnit, 'ortb2Imp.ext.gpid')
+        break;
+    }
+
+    const placementLegacy = deepAccess(adUnit, 'ortb2Imp.ext.data.placement', '');
+
+    return placementFromSource || placementLegacy;
   }
 };
 
@@ -317,7 +336,6 @@ function onBidRequest(bidderRequest, config, _userConsent) {
  * @param {*} config
  */
 function onGetBidRequestData(bidReqConfig, callback, config) {
-  const configParams = deepAccess(config, 'params', {});
   const { site: ortb2Site } = bidReqConfig.ortb2Fragments.global;
   const features = _internal.getFeatures().get();
   const ext = {
@@ -345,30 +363,11 @@ function onGetBidRequestData(bidReqConfig, callback, config) {
     const slotPosition = getSlotPosition(divId);
     deepSetValue(ortb2Imp, `ext.data.adg_rtd.adunit_position`, slotPosition);
 
-    // It is expected that the publisher set a `adUnits[].ortb2Imp.ext.data.placement` value.
-    // Btw, We allow fallback sources to programmatically set this value.
-    // The source is defined in the `config.params.placementSource` and the possible values are `code` or `gpid`.
-    // (Please note that this `placement` is not related to the oRTB video property.)
-    if (!deepAccess(ortb2Imp, 'ext.data.placement')) {
-      const { placementSource = '' } = configParams;
-
-      switch (placementSource.toLowerCase()) {
-        case PLACEMENT_SOURCES.ADUNITCODE:
-          deepSetValue(ortb2Imp, 'ext.data.placement', adUnit.code);
-          break;
-        case PLACEMENT_SOURCES.GPID:
-          deepSetValue(ortb2Imp, 'ext.data.placement', deepAccess(ortb2Imp, 'ext.gpid'));
-          break;
-        default:
-          logWarn('`ortb2Imp.ext.data.placement` is missing and `params.definePlacement` is not set in the config.');
-      }
-    }
-
-    // We expect that `pagetype`, `category`, `placement` are defined in FPD `ortb2.site.ext.data` and `adUnits[].ortb2Imp.ext.data` objects.
-    // Btw, we have to ensure compatibility with publishers that use the "legacy" adagio params at the adUnit.params level.
     const adagioBid = adUnit.bids.find(bid => _internal.isAdagioBidder(bid.bidder));
     if (adagioBid) {
       // ortb2 level
+      // We expect that `pagetype`, `category` are defined in FPD `ortb2.site.ext.data` object.
+      // Btw, we still ensure compatibility with publishers that use the adagio params at the adUnit.params level.
       let mustWarnOrtb2 = false;
       if (!deepAccess(ortb2Site, 'ext.data.pagetype') && adagioBid.params.pagetype) {
         deepSetValue(ortb2Site, 'ext.data.pagetype', adagioBid.params.pagetype);
@@ -378,21 +377,28 @@ function onGetBidRequestData(bidReqConfig, callback, config) {
         deepSetValue(ortb2Site, 'ext.data.category', adagioBid.params.category);
         mustWarnOrtb2 = true;
       }
-
-      // ortb2Imp level
-      let mustWarnOrtb2Imp = false;
-      if (!deepAccess(ortb2Imp, 'ext.data.placement')) {
-        if (adagioBid.params.placement) {
-          deepSetValue(ortb2Imp, 'ext.data.placement', adagioBid.params.placement);
-          mustWarnOrtb2Imp = true;
-        }
-      }
-
       if (mustWarnOrtb2) {
-        logWarn('`pagetype` and `category` must be defined in the FPD `ortb2.site.ext.data` object. Relying on `adUnits[].bids.adagio.params` is deprecated.');
+        logInfo('`pagetype` and/or `category` have been set in the FPD `ortb2.site.ext.data` object from `adUnits[].bids.adagio.params`.');
       }
-      if (mustWarnOrtb2Imp) {
-        logWarn('`placement` must be defined in the FPD `adUnits[].ortb2Imp.ext.data` object. Relying on `adUnits[].bids.adagio.params` is deprecated.');
+
+      // ortb2Imp level to handle legacy.
+      // The `placement` is finally set at the adUnit.params level (see https://github.com/prebid/Prebid.js/issues/12845)
+      // but we still need to set it at the ortb2Imp level for our internal use.
+      const placementParam = adagioBid.params.placement;
+      const adgRtdPlacement = deepAccess(ortb2Imp, 'ext.data.adg_rtd.placement', '');
+
+      if (placementParam) {
+        // Always overwrite the ortb2Imp value with the one from the adagio adUnit.params.placement if defined.
+        // This is the common case.
+        deepSetValue(ortb2Imp, 'ext.data.adg_rtd.placement', placementParam);
+      }
+
+      if (!placementParam && !adgRtdPlacement) {
+        const p = _internal.computePlacementFromLegacy(config, adUnit);
+        if (p) {
+          deepSetValue(ortb2Imp, 'ext.data.adg_rtd.placement', p);
+          logWarn('`ortb2Imp.ext.data.adg_rtd.placement` has been set from a legacy source. Please set `bids[].adagio.params.placement` or `ortb2Imp.ext.data.adg_rtd.placement` value.');
+        }
       }
     }
   });

--- a/test/spec/modules/adagioAnalyticsAdapter_spec.js
+++ b/test/spec/modules/adagioAnalyticsAdapter_spec.js
@@ -4,6 +4,7 @@ import adagioAnalyticsAdapter, { _internal } from 'modules/adagioAnalyticsAdapte
 import { EVENTS } from 'src/constants.js';
 import { expect } from 'chai';
 import { server } from 'test/mocks/xhr.js';
+import { deepClone } from 'src/utils.js';
 
 let adapterManager = require('src/adapterManager').default;
 let events = require('src/events');
@@ -191,8 +192,10 @@ const BID_CACHED = Object.assign({}, BID_ADAGIO, {
   latestTargetedAuctionId: BID_ADAGIO.auctionId,
 });
 
+const PARAMS_PLCMT = 'placement_from_params';
 const PARAMS_ADG = {
   environment: 'desktop',
+  placement: PARAMS_PLCMT,
 };
 
 const ORTB_DATA = {
@@ -205,6 +208,13 @@ const ADG_RTD = {
     'testName': 'test',
     'testVersion': 'version',
     'id': SESSION_ID,
+  }
+};
+
+const ORTB2IMP_PLCMT = 'placement_from_ortb2imp';
+const ORTB2IMP_DATA_ADG = {
+  'adg_rtd': {
+    'placement': ORTB2IMP_PLCMT
   }
 };
 
@@ -226,6 +236,11 @@ const AUCTION_INIT_ANOTHER = {
             100
           ]
         ]
+      }
+    },
+    'ortb2Imp': {
+      'ext': {
+        'data': ORTB2IMP_DATA_ADG
       }
     },
     'sizes': [[640, 480]],
@@ -250,14 +265,7 @@ const AUCTION_INIT_ANOTHER = {
         'publisherId': '1001'
       },
     }, ],
-    'transactionId': 'ca4af27a-6d02-4f90-949d-d5541fa12014',
-    'ortb2Imp': {
-      'ext': {
-        'data': {
-          'placement': 'pave_top',
-        }
-      }
-    },
+    'transactionId': 'ca4af27a-6d02-4f90-949d-d5541fa12014'
   }, {
     'code': '/19968336/footer-bid-tag-1',
     'mediaTypes': {
@@ -281,7 +289,9 @@ const AUCTION_INIT_ANOTHER = {
     'ortb2Imp': {
       'ext': {
         'data': {
-          'placement': 'pave_top',
+          'adg_rtd': {
+            'placement': 'footer'
+          }
         }
       }
     },
@@ -301,6 +311,11 @@ const AUCTION_INIT_ANOTHER = {
           'mediaTypes': {
             'banner': {
               'sizes': [[640, 480]]
+            }
+          },
+          'ortb2Imp': {
+            'ext': {
+              'data': ORTB2IMP_DATA_ADG
             }
           },
           'adUnitCode': '/19968336/header-bid-tag-1',
@@ -363,6 +378,12 @@ const AUCTION_INIT_ANOTHER = {
             'sizes': [[640, 480]]
           }
         },
+
+        'ortb2Imp': {
+          'ext': {
+            'data': ORTB2IMP_DATA_ADG
+          }
+        },
         'adUnitCode': '/19968336/header-bid-tag-1',
         'transactionId': 'ca4af27a-6d02-4f90-949d-d5541fa12014',
         'sizes': [[640, 480]],
@@ -403,6 +424,11 @@ const AUCTION_INIT_ANOTHER = {
           'mediaTypes': {
             'banner': {
               'sizes': [[640, 480]]
+            }
+          },
+          'ortb2Imp': {
+            'ext': {
+              'data': ORTB2IMP_DATA_ADG
             }
           },
           'adUnitCode': '/19968336/header-bid-tag-1',
@@ -453,7 +479,12 @@ const AUCTION_INIT_ANOTHER = {
         'bidderRequestId': '1be65d7958826a',
         'auctionId': AUCTION_ID,
         'src': 'client',
-        'bidRequestsCount': 1
+        'bidRequestsCount': 1,
+        'ortb2Imp': {
+          'ext': {
+            'data': ORTB2IMP_DATA_ADG
+          }
+        },
       }
       ],
       'timeout': 3000,
@@ -514,9 +545,7 @@ const AUCTION_INIT_CACHE = {
     'transactionId': 'ca4af27a-6d02-4f90-949d-d5541fa12014',
     'ortb2Imp': {
       'ext': {
-        'data': {
-          'placement': 'pave_top',
-        }
+        'data': ORTB2IMP_DATA_ADG
       }
     },
   }, {
@@ -539,13 +568,6 @@ const AUCTION_INIT_CACHE = {
       },
     } ],
     'transactionId': 'ca4af27a-6d02-4f90-949d-d5541fa12014',
-    'ortb2Imp': {
-      'ext': {
-        'data': {
-          'placement': 'pave_top',
-        }
-      }
-    },
   } ],
   'adUnitCodes': ['/19968336/header-bid-tag-1', '/19968336/footer-bid-tag-1'],
   'bidderRequests': [ {
@@ -560,6 +582,11 @@ const AUCTION_INIT_CACHE = {
       'mediaTypes': {
         'banner': {
           'sizes': [[640, 480]]
+        }
+      },
+      'ortb2Imp': {
+        'ext': {
+          'data': ORTB2IMP_DATA_ADG
         }
       },
       'adUnitCode': '/19968336/header-bid-tag-1',
@@ -619,6 +646,11 @@ const AUCTION_INIT_CACHE = {
       'mediaTypes': {
         'banner': {
           'sizes': [[640, 480]]
+        }
+      },
+      'ortb2Imp': {
+        'ext': {
+          'data': ORTB2IMP_DATA_ADG
         }
       },
       'adUnitCode': '/19968336/header-bid-tag-1',
@@ -818,7 +850,7 @@ describe('adagio analytics adapter', () => {
         expect(search.pv_id).to.equal('a68e6d70-213b-496c-be0a-c468ff387106');
         expect(search.url_dmn).to.equal(window.location.hostname);
         expect(search.pgtyp).to.equal('article');
-        expect(search.plcmt).to.equal('pave_top');
+        expect(search.plcmt).to.equal(ORTB2IMP_PLCMT);
         expect(search.mts).to.equal('ban');
         expect(search.ban_szs).to.equal('640x100,640x480');
         expect(search.bdrs).to.equal('adagio,another,anotherWithAlias,nobid');
@@ -869,11 +901,49 @@ describe('adagio analytics adapter', () => {
         expect(search.auct_id).to.equal(RTD_AUCTION_ID);
         expect(search.adu_code).to.equal('/19968336/header-bid-tag-1');
         expect(search.win_bdr).to.equal('another');
+        expect(search.plcmt).to.equal(ORTB2IMP_PLCMT);
         expect(search.win_mt).to.equal('ban');
         expect(search.win_ban_sz).to.equal('728x90');
         expect(search.win_net_cpm).to.equal('2.052');
         expect(search.win_og_cpm).to.equal('2.592');
         expect(search.bdrs_timeout).to.equal('0,0,0,0');
+      }
+    });
+
+    it('it fallback on the adUnit.params.placement value if adg_rtd.placement is not set', () => {
+      const mockAuctionInit = deepClone(MOCK.AUCTION_INIT.another);
+      for (const adUnit of mockAuctionInit.adUnits) {
+        delete adUnit.ortb2Imp?.ext?.data.adg_rtd;
+      }
+      for (const bidRequest of mockAuctionInit.bidderRequests) {
+        for (const bid of bidRequest.bids) {
+          delete bid.ortb2Imp?.ext?.data.adg_rtd;
+        }
+      }
+
+      events.emit(EVENTS.AUCTION_INIT, mockAuctionInit);
+      {
+        const { protocol, hostname, pathname, search } = utils.parseUrl(server.requests[0].url);
+        expect(protocol).to.equal('https');
+        expect(hostname).to.equal('c.4dex.io');
+        expect(pathname).to.equal('/pba.gif');
+        expect(search.v).to.equal('1');
+        expect(search.pbjsv).to.equal('$prebid.version$');
+        expect(search.s_id).to.equal(SESSION_ID);
+        expect(search.auct_id).to.equal(RTD_AUCTION_ID);
+        expect(search.adu_code).to.equal('/19968336/header-bid-tag-1');
+        expect(search.org_id).to.equal('1001');
+        expect(search.site).to.equal('test-com');
+        expect(search.pv_id).to.equal('a68e6d70-213b-496c-be0a-c468ff387106');
+        expect(search.url_dmn).to.equal(window.location.hostname);
+        expect(search.pgtyp).to.equal('article');
+        expect(search.plcmt).to.equal(PARAMS_PLCMT);
+        expect(search.mts).to.equal('ban');
+        expect(search.ban_szs).to.equal('640x100,640x480');
+        expect(search.bdrs).to.equal('adagio,another,anotherWithAlias,nobid');
+        expect(search.bdrs_code).to.equal('adagio,another,another,nobid');
+        expect(search.bdrs_timeout).to.not.exist;
+        expect(search.adg_mts).to.equal('ban');
       }
     });
 
@@ -903,7 +973,7 @@ describe('adagio analytics adapter', () => {
         expect(search.pv_id).to.equal('a68e6d70-213b-496c-be0a-c468ff387106');
         expect(search.url_dmn).to.equal(window.location.hostname);
         expect(search.pgtyp).to.equal('article');
-        expect(search.plcmt).to.equal('pave_top');
+        expect(search.plcmt).to.equal(ORTB2IMP_PLCMT);
         expect(search.mts).to.equal('ban');
         expect(search.ban_szs).to.equal('640x100,640x480');
         expect(search.bdrs).to.equal('adagio,another');
@@ -928,7 +998,7 @@ describe('adagio analytics adapter', () => {
         expect(search.pv_id).to.equal('a68e6d70-213b-496c-be0a-c468ff387106');
         expect(search.url_dmn).to.equal(window.location.hostname);
         expect(search.pgtyp).to.equal('article');
-        expect(search.plcmt).to.equal('pave_top');
+        expect(search.plcmt).to.be.undefined; // no placement set, no adagio bidder for this adUnit.
         expect(search.mts).to.equal('ban');
         expect(search.ban_szs).to.equal('640x480');
         expect(search.bdrs).to.equal('another');
@@ -951,7 +1021,7 @@ describe('adagio analytics adapter', () => {
         expect(search.pv_id).to.equal('a68e6d70-213b-496c-be0a-c468ff387106');
         expect(search.url_dmn).to.equal(window.location.hostname);
         expect(search.pgtyp).to.equal('article');
-        expect(search.plcmt).to.equal('pave_top');
+        expect(search.plcmt).to.equal(ORTB2IMP_PLCMT);
         expect(search.mts).to.equal('ban');
         expect(search.ban_szs).to.equal('640x100,640x480');
         expect(search.bdrs).to.equal('adagio,another,anotherWithAlias,nobid');

--- a/test/spec/modules/adagioRtdProvider_spec.js
+++ b/test/spec/modules/adagioRtdProvider_spec.js
@@ -507,7 +507,7 @@ describe('Adagio Rtd Provider', function () {
       expect(ortb2ImpExt.adunit_position).equal('');
     });
 
-    describe('update the ortb2Imp.ext.data.placement if not present', function() {
+    describe('set the ortb2Imp.ext.data.adg_rtd.placement', function() {
       const config = {
         name: SUBMODULE_NAME,
         params: {
@@ -516,31 +516,7 @@ describe('Adagio Rtd Provider', function () {
         }
       };
 
-      it('update the placement value with the adUnit.code value', function() {
-        const configCopy = utils.deepClone(config);
-        configCopy.params.placementSource = PLACEMENT_SOURCES.ADUNITCODE;
-
-        const bidRequest = utils.deepClone(bidReqConfig);
-
-        adagioRtdSubmodule.getBidRequestData(bidRequest, cb, configCopy);
-        expect(bidRequest.adUnits[0]).to.have.property('ortb2Imp');
-        expect(bidRequest.adUnits[0].ortb2Imp.ext.data.placement).to.equal('div-gpt-ad-1460505748561-0');
-      });
-
-      it('update the placement value with the gpid value', function() {
-        const configCopy = utils.deepClone(config);
-        configCopy.params.placementSource = PLACEMENT_SOURCES.GPID;
-
-        const bidRequest = utils.deepClone(bidReqConfig);
-        const gpid = '/19968336/header-bid-tag-0'
-        utils.deepSetValue(bidRequest.adUnits[0], 'ortb2Imp.ext.gpid', gpid)
-
-        adagioRtdSubmodule.getBidRequestData(bidRequest, cb, configCopy);
-        expect(bidRequest.adUnits[0]).to.have.property('ortb2Imp');
-        expect(bidRequest.adUnits[0].ortb2Imp.ext.data.placement).to.equal(gpid);
-      });
-
-      it('update the placement value the legacy adUnit[].bids adagio.params.placement value', function() {
+      it('set the adg_rtd.placement value from the adUnit[].bids adagio.params.placement value', function() {
         const placement = 'placement-value';
 
         const configCopy = utils.deepClone(config);
@@ -550,16 +526,40 @@ describe('Adagio Rtd Provider', function () {
 
         adagioRtdSubmodule.getBidRequestData(bidRequest, cb, configCopy);
         expect(bidRequest.adUnits[0]).to.have.property('ortb2Imp');
-        expect(bidRequest.adUnits[0].ortb2Imp.ext.data.placement).to.equal(placement);
+        expect(bidRequest.adUnits[0].ortb2Imp.ext.data.adg_rtd.placement).to.equal(placement);
       });
 
-      it('it does not populate `ortb2Imp.ext.data.placement` if no fallback', function() {
+      it('fallback on the adUnit.code value to set the adg_rtd.placement value', function() {
+        const configCopy = utils.deepClone(config);
+        configCopy.params.placementSource = PLACEMENT_SOURCES.ADUNITCODE;
+
+        const bidRequest = utils.deepClone(bidReqConfig);
+
+        adagioRtdSubmodule.getBidRequestData(bidRequest, cb, configCopy);
+        expect(bidRequest.adUnits[0]).to.have.property('ortb2Imp');
+        expect(bidRequest.adUnits[0].ortb2Imp.ext.data.adg_rtd.placement).to.equal('div-gpt-ad-1460505748561-0');
+      });
+
+      it('fallback on the the gpid value to set the adg_rtd.placement value ', function() {
+        const configCopy = utils.deepClone(config);
+        configCopy.params.placementSource = PLACEMENT_SOURCES.GPID;
+
+        const bidRequest = utils.deepClone(bidReqConfig);
+        const gpid = '/19968336/header-bid-tag-0'
+        utils.deepSetValue(bidRequest.adUnits[0], 'ortb2Imp.ext.gpid', gpid)
+
+        adagioRtdSubmodule.getBidRequestData(bidRequest, cb, configCopy);
+        expect(bidRequest.adUnits[0]).to.have.property('ortb2Imp');
+        expect(bidRequest.adUnits[0].ortb2Imp.ext.data.adg_rtd.placement).to.equal(gpid);
+      });
+
+      it('it does not populate `ortb2Imp.ext.data.adg_rtd.placement` if no fallback', function() {
         const configCopy = utils.deepClone(config);
         const bidRequest = utils.deepClone(bidReqConfig);
 
         adagioRtdSubmodule.getBidRequestData(bidRequest, cb, configCopy);
         expect(bidRequest.adUnits[0]).to.have.property('ortb2Imp');
-        expect(bidRequest.adUnits[0].ortb2Imp.ext.data.placement).to.not.exist;
+        expect(bidRequest.adUnits[0].ortb2Imp.ext.data.adg_rtd.placement).to.not.exist;
       });
 
       it('ensure we create the `ortb2Imp` object if it does not exist', function() {
@@ -571,7 +571,7 @@ describe('Adagio Rtd Provider', function () {
 
         adagioRtdSubmodule.getBidRequestData(bidRequest, cb, configCopy);
         expect(bidRequest.adUnits[0]).to.have.property('ortb2Imp');
-        expect(bidRequest.adUnits[0].ortb2Imp.ext.data.placement).to.equal('div-gpt-ad-1460505748561-0');
+        expect(bidRequest.adUnits[0].ortb2Imp.ext.data.adg_rtd.placement).to.equal('div-gpt-ad-1460505748561-0');
       });
     });
   });


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
- [x] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [x] Other

## Description of change

- move FPD signal `ortb2Imp.ext.data.placement` to `ortb2Imp.ext.data.adg_rtd.placement`
- when using the adagioRTDProvider, rely on the adagio param "placement" to auto-set the `ortb2Imp.ext.data.adg_rtd.placement` signal _(we still need this signal)_.
- Remove `params.placement` deprecation warning 
- ensure backward compatibility for the 3 adagio* modules



| Priority | Source                           | if present? |
|----------|----------------------------------|----------------------|
| 1        | `adUnit.params.placement`        | ✅ always prioritary |
| 2        | `ortb2Imp.ext.data.adg_rtd.placement` | ✅ Used if no `adUnit.params.placement` |
| 3        | `ortb2Imp.ext.data.placement`    | ✅ Used only if neither of the two above exists |

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
Close [12845](https://github.com/prebid/Prebid.js/issues/12845)